### PR TITLE
Create a Source generic relation.

### DIFF
--- a/popolo/models.py
+++ b/popolo/models.py
@@ -53,7 +53,7 @@ class Person(Dateframeable, Timestampable, Permalinkable, models.Model):
         return self.membership_set.all()
 
     # array of items referencing "http://popoloproject.com/schemas/link.json#"
-    sources = generic.GenericRelation('Link', help_text="URLs to source documents about the person", related_name='source_person_set')
+    sources = generic.GenericRelation('Source', help_text="URLs to source documents about the person")
 
     @property
     def slug_source(self):
@@ -130,7 +130,7 @@ class Organization(Dateframeable, Timestampable, Permalinkable, models.Model):
         return self.post_set.all()
 
     # array of items referencing "http://popoloproject.com/schemas/link.json#"
-    sources = generic.GenericRelation('Link', help_text="URLs to source documents about the organization", related_name='source_organization_set')
+    sources = generic.GenericRelation('Source', help_text="URLs to source documents about the organization")
 
     @property
     def slug_source(self):
@@ -181,7 +181,7 @@ class Post(Dateframeable, Timestampable, Permalinkable, models.Model):
         return self.membership_set.all()
 
     # array of items referencing "http://popoloproject.com/schemas/link.json#"
-    sources = generic.GenericRelation('Link', help_text="URLs to source documents about the post", related_name='source_post_set')
+    sources = generic.GenericRelation('Source', help_text="URLs to source documents about the post")
 
     @property
     def slug_source(self):
@@ -223,7 +223,7 @@ class Membership(Dateframeable, Timestampable, models.Model):
     links = generic.GenericRelation('Link', help_text="URLs to documents about the membership")
 
     # array of items referencing "http://popoloproject.com/schemas/link.json#"
-    sources = generic.GenericRelation('Link', help_text="URLs to source documents about the membership", related_name='source_membership_set')
+    sources = generic.GenericRelation('Source', help_text="URLs to source documents about the membership")
 
     @property
     def slug_source(self):
@@ -254,7 +254,7 @@ class ContactDetail(Timestampable, Dateframeable, GenericRelatable,  models.Mode
 
 
     # array of items referencing "http://popoloproject.com/schemas/link.json#"
-    sources = generic.GenericRelation('Link', help_text="URLs to source documents about the contact detail")
+    sources = generic.GenericRelation('Source', help_text="URLs to source documents about the contact detail")
 
     objects = PassThroughManager.for_queryset_class(ContactDetailQuerySet)()
 
@@ -287,6 +287,14 @@ class Link(GenericRelatable, models.Model):
     """
     url = models.URLField(_("url"), help_text=_("A URL"))
     note = models.CharField(_("note"), max_length=128, blank=True, help_text=_("A note, e.g. 'Wikipedia page'"))
+
+
+class Source(GenericRelatable, models.Model):
+    """
+    A URL for referring to sources of information
+    """
+    url = models.URLField(_("url"), help_text=_("A URL"))
+    note = models.CharField(_("note"), max_length=128, blank=True, help_text=_("A note, e.g. 'Parliament website'"))
 
 ##
 ## signals

--- a/popolo/tests.py
+++ b/popolo/tests.py
@@ -58,8 +58,12 @@ class PersonTestCase(DateframeableTests, TimestampableTests, PermalinkableTests,
         p.add_contact_details(contacts)
         self.assertEqual(p.contact_details.count(), 2)
 
-
-
+    def test_add_links_and_sources(self):
+        p = self.create_instance()
+        p.links.create( url='http://link.example.org/', note='Note' )
+        p.sources.create( url='http://source.example.org/', note='Source note' )
+        self.assertEqual(p.links.count(), 1)
+        self.assertEqual(p.sources.filter(url='http://link.example.org/').count(), 0)
 
 class OrganizationTestCase(DateframeableTests, TimestampableTests, PermalinkableTests, TestCase):
     model = Organization


### PR DESCRIPTION
If a model has two GenericRelations to the same model, there is no way to differentiate between them. So this pull request adds a new Source model to be used for sources, along with a test to show the problem.
