### PR TITLE
Make organization optional on a membership.

### DIFF
--- a/popolo/models.py
+++ b/popolo/models.py
@@ -203,7 +203,7 @@ class Membership(Dateframeable, Timestampable, models.Model):
                                help_text=_("The person who is a party to the relationship"))
 
     # reference to "http://popoloproject.com/schemas/organization.json#"
-    organization = models.ForeignKey('Organization', related_name='memberships',
+    organization = models.ForeignKey('Organization', blank=True, null=True, related_name='memberships',
                                      help_text=_("The organization that is a party to the relationship"))
     on_behalf_of = models.ForeignKey('Organization', blank=True, null=True,
                                      related_name='memberships_on_behalf_of',


### PR DESCRIPTION
As of 2014-10-28, Popolo allows a membership to have no organization if it has a post.

See an example at:
http://www.popoloproject.com/appendices/examples.html#electoral-candidate