### PR TITLE
Refactoring lambda function that determined the source for the slug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: python
 python:
   - "2.7"
   - "3.3"
+env:
+   - DJANGO_VERSION=1.6.1
+   - DJANGO_VERSION=1.8
+
 install: 
+  - "pip install Django==$DJANGO_VERSION"
   - "pip install -r tests_requirements.txt"
   - "python setup.py install"
   - "pip install coveralls"

--- a/popolo/behaviors/models.py
+++ b/popolo/behaviors/models.py
@@ -11,6 +11,10 @@ from datetime import datetime
 __author__ = 'guglielmo'
 
 
+def get_populate_from(instance):
+    return instance.slug_source
+
+
 class GenericRelatable(models.Model):
     """
     An abstract class that provides the possibility of generic relations
@@ -83,7 +87,7 @@ class Permalinkable(models.Model):
     from django.utils.text import slugify
 
     slug = AutoSlugField(
-        populate_from=lambda instance: instance.slug_source,
+        populate_from=get_populate_from,
         unique=True,
         slugify=slugify
     )

--- a/popolo/models.py
+++ b/popolo/models.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 
-from .behaviors.models import Permalinkable, Timestampable, Dateframeable, GenericRelatable
+from .behaviors.models import Permalinkable, Timestampable, Dateframeable, GenericRelatable, get_populate_from
 from .querysets import PostQuerySet, OtherNameQuerySet, ContactDetailQuerySet, MembershipQuerySet, OrganizationQuerySet, PersonQuerySet
 
 
@@ -25,7 +25,7 @@ class Person(Dateframeable, Timestampable, models.Model):
     json_ld_type = "http://www.w3.org/ns/person#Person"
 
     id = AutoSlugField(
-        populate_from=lambda instance: instance.slug_source,
+        populate_from=get_populate_from,
         primary_key=True, max_length=256,
         slugify=slugify
     )
@@ -100,7 +100,7 @@ class Organization(Dateframeable, Timestampable, Permalinkable, models.Model):
     see schema at http://popoloproject.com/schemas/organization.json#
     """
     id = AutoSlugField(
-        populate_from=lambda instance: instance.slug_source,
+        populate_from=get_populate_from,
         primary_key=True, max_length=256,
         slugify=slugify
     )
@@ -180,7 +180,7 @@ class Post(Dateframeable, Timestampable, models.Model):
     see schema at http://popoloproject.com/schemas/json#
     """
     id = AutoSlugField(
-        populate_from=lambda instance: instance.slug_source,
+        populate_from=get_populate_from,
         primary_key=True, max_length=256,
         slugify=slugify
     )
@@ -384,7 +384,7 @@ class Area(GenericRelatable, Dateframeable, Timestampable, models.Model):
     see schema at http://popoloproject.com/schemas/area.json#
     """
     id = AutoSlugField(
-        populate_from=lambda instance: instance.slug_source,
+        populate_from=get_populate_from,
         primary_key=True, max_length=256,
         slugify=slugify
     )

--- a/runtests.py
+++ b/runtests.py
@@ -23,11 +23,14 @@ if not settings.configured:
 
 
 from django.test.utils import get_runner
+import django
 
 
 def runtests():
     TestRunner = get_runner(settings)
     test_runner = TestRunner(verbosity=1, interactive=True, failfast=False)
+    if django.get_version() >= '1.8':
+        django.setup()
     failures = test_runner.run_tests(['popolo', ])
     sys.exit(failures)
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     classifiers=[
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Intended Audience :: Developers',
-        'Programming Language :: Python',      
+        'Programming Language :: Python',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Framework :: Django',
@@ -36,7 +36,7 @@ setup(
     test_suite="runtests.runtests",
     zip_safe=False,
     install_requires=[
-        "django-autoslug",
+        "django-autoslug==1.8.0",
         "django-model-utils",
     ],
 )

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,2 +1,1 @@
-Django==1.6.1
 fake-factory==0.3.2


### PR DESCRIPTION
This PR contains the following:

* Using a named function instead of a lambda functions for determining the source for the slug in several models.
* Running tests against Django>=1.8

By having a named function instead of a lambda we could easily change how it behaves. And also it removes repeated code.
Another advantage of having a named function is that we could create migrations in the future.
