### PR TITLE
Fix editing of Post objects in the admin interface

### DIFF
--- a/popolo/admin.py
+++ b/popolo/admin.py
@@ -58,7 +58,7 @@ class PostAdmin(admin.ModelAdmin):
         }),
         ('Details', {
             'classes': ('collapse',),
-            'fields': ('other_label', 'area', 'organization','membership')
+            'fields': ('other_label', 'area', 'organization')
         }),
     )
     inlines = [


### PR DESCRIPTION
Post doesn't have a 'membership' field, and having this listed in
fields for PostAdmin causes all the post-related pages in the admin
to error.

Thanks to @lfalvarez for spotting this problem.