### PR TITLE
Set a default for organization classification in Popit importer

### DIFF
--- a/popolo/importers/popit.py
+++ b/popolo/importers/popit.py
@@ -178,7 +178,7 @@ class PopItImporter(object):
         else:
             result = existing
         result.name = org_data['name']
-        result.classification = org_data['classification']
+        result.classification = org_data.get('classification', '')
         result.dissolution_date = org_data.get('dissolution_date', '')
         result.founding_date = org_data.get('founding_date', '')
         result.image = org_data.get('image') or None


### PR DESCRIPTION
This just tweaks the importer to cope if an organization doesn't have a classification property.