### PR TITLE
Test more versions of Django.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,15 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO_VERSION='>=1.6,<1.9'
+  - DJANGO_VERSION='>=1.7,<1.8'
+  - DJANGO_VERSION='>=1.8,<1.9'
+  - DJANGO_VERSION='>=1.9,<1.10'
+matrix:
+  exclude:
+    - python: "3.3"
+      env: DJANGO_VERSION='>=1.9,<1.10'
+    - python: "3.5"
+      env: DJANGO_VERSION='>=1.7,<1.8'
 install:
   - "pip install Django$DJANGO_VERSION"
   - "pip install -r tests_requirements.txt"

--- a/popolo/migrations/0001_initial.py
+++ b/popolo/migrations/0001_initial.py
@@ -13,7 +13,7 @@ import django.core.validators
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('contenttypes', '0002_remove_content_type_name'),
+        ('contenttypes', '0001_initial'),
     ]
 
     operations = [


### PR DESCRIPTION
Currently, the travis line stated only tests 1.8. The commit message of 349f3199 isn't clear as to whether that was intended or not, but this PR fixes it to test 1.7, 1.8, and 1.9 (1.7 isn't supported by Django any more but given there is specific code for it, I thought it might as well).
