### PR TITLE
Fix bug in printing an Identifier.

### DIFF
--- a/popolo/models.py
+++ b/popolo/models.py
@@ -374,7 +374,7 @@ class Identifier(GenericRelatable, models.Model):
     scheme = models.CharField(_("scheme"), max_length=128, blank=True, help_text=_("An identifier scheme, e.g. DUNS"))
 
     def __str__(self):
-        return "{0}: {1}".format(self.scheme, self.identifier)
+        return u"{0}: {1}".format(self.scheme, self.identifier)
 
 
 @python_2_unicode_compatible
@@ -472,7 +472,7 @@ class AreaI18Name(models.Model):
     name = models.CharField(_("name"), max_length=255)
 
     def __str__(self):
-        return "{0} - {1}".format(self.language, self.name)
+        return u"{0} - {1}".format(self.language, self.name)
 
     class Meta:
         verbose_name = 'I18N Name'

--- a/popolo/tests.py
+++ b/popolo/tests.py
@@ -4,6 +4,7 @@ Run with "manage.py test popolo, or with python".
 """
 
 from django.test import TestCase
+from django.utils.encoding import force_text
 from popolo.behaviors.tests import TimestampableTests, DateframeableTests, PermalinkableTests
 from popolo.models import Person, Organization, Post, ContactDetail, Area, Identifier
 from faker import Factory
@@ -60,6 +61,12 @@ class PersonTestCase(DateframeableTests, TimestampableTests, TestCase):
         self.assertEqual(p.memberships.count(), 1)
 
     def test_add_contact_detail(self):
+        p = self.create_instance()
+        i = Identifier.objects.create(content_object=p, scheme='test', identifier=u'AB\u2013123')
+        self.assertEqual(force_text(i), u'test: AB\u2013123')
+        self.assertEqual(p.identifiers.count(), 1)
+
+    def test_add_identifier(self):
         p = self.create_instance()
         p.add_contact_detail(contact_type=ContactDetail.CONTACT_TYPES.email, value=faker.email())
         self.assertEqual(p.contact_details.count(), 1)


### PR DESCRIPTION
The Identifier model and one other were not creating Unicode strings, so
raised an exception when given non-ASCII data.
